### PR TITLE
Fix linux

### DIFF
--- a/recipes/gnuplot/meta.yaml
+++ b/recipes/gnuplot/meta.yaml
@@ -1,6 +1,7 @@
 {% set pkgname = "gnuplot" %}
 {% set version = "5.0.5" %}
 {% set sha256 = "25f3e0bf192e01115c580f278c3725d7a569eb848786e12b455a3fda70312053" %}
+
 package:
   name: {{ pkgname }}
   version: {{ version }}
@@ -16,6 +17,7 @@ build:
 
 requirements:
   build:
+    - gcc  # [linux]
     - pkgconfig
     - ncurses 5.9*
     - readline 6.2*
@@ -24,6 +26,7 @@ requirements:
     - qt 4.8.*
     - pango >1.10
   run:
+    - libgcc  # [linux]
     - ncurses 5.9*
     - readline 6.2*
     - libgd


### PR DESCRIPTION
This will enable Linux builds. Somehow the docker image `gcc` is not OK for this package.